### PR TITLE
fix typo for book 'Effective Java'

### DIFF
--- a/data/map-DevLang-Java.md
+++ b/data/map-DevLang-Java.md
@@ -53,7 +53,7 @@
 	* http://www.tutorialspoint.com/data_structures_algorithms/
 - Object Oriented Programming *
 	* head_first_design_patterns.pdf
-	* heaEffective Java 2nd Edition.pdf
+	* Effective Java 2nd Edition.pdf
 - Computer Architecture
 	* Memory Hierarchy
 	* Parallelism


### PR DESCRIPTION
There is a typo of the book's name. I'd like to fix it quickly.